### PR TITLE
Fix HMR and glob support

### DIFF
--- a/catalog.d.ts
+++ b/catalog.d.ts
@@ -12,4 +12,4 @@ type ArticleContentProps<TVariables> = {
 
 export function ArticleContent<TVariables = Record<string, any>>(
   props: ArticleContentProps<TVariables>,
-): JSX.Element;
+): React.ReactNode;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apocrypha/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "an engine for building websites with vite and markdoc",
   "license": "MIT",
   "author": "Nate Kohari <nkohari@gmail.com>",

--- a/src/apocrypha.ts
+++ b/src/apocrypha.ts
@@ -70,8 +70,8 @@ export function apocrypha<TMeta extends object = Record<string, any>>(
       };
 
       catalog.on('add', invalidateCatalogModule);
-      catalog.on('change', invalidateCatalogModule);
       catalog.on('remove', invalidateCatalogModule);
+
       catalog.startWatching();
     },
 
@@ -111,7 +111,7 @@ export function apocrypha<TMeta extends object = Record<string, any>>(
 
       const ast = parser.parse(text);
       const document = await catalog.getDocument(id);
-      const code = codeGenerator.renderArticleModule(ast, document.metadata);
+      const code = codeGenerator.renderArticleModule(ast, document.metadata, document.path);
 
       return { code };
     },

--- a/src/services/DocumentCatalog.ts
+++ b/src/services/DocumentCatalog.ts
@@ -14,18 +14,14 @@ export class DocumentCatalog<TMeta extends object> extends EventEmitter {
   documents: Record<string, Document<TMeta>>;
   documentFactory: DocumentFactory<TMeta>;
   fsWatcher?: FSWatcher;
-  globPattern: string;
   paths: Paths;
 
   private initialScanPromise: Maybe<Promise<void>>;
 
   constructor({ documentFactory, paths }: DocumentCatalogParams<TMeta>) {
     super();
-
     this.documentFactory = documentFactory;
     this.paths = paths;
-
-    this.globPattern = `${this.paths.content}**/*.md`;
     this.documents = {};
   }
 
@@ -43,7 +39,7 @@ export class DocumentCatalog<TMeta extends object> extends EventEmitter {
     await this.waitForInitialScan();
 
     return new Promise<void>((resolve) => {
-      this.fsWatcher = chokidar.watch(this.globPattern, {
+      this.fsWatcher = chokidar.watch(this.paths.content, {
         persistent: true,
         ignoreInitial: true,
       });
@@ -68,7 +64,7 @@ export class DocumentCatalog<TMeta extends object> extends EventEmitter {
   }
 
   private async performInitialScan() {
-    const filenames = await glob(this.globPattern, { absolute: true });
+    const filenames = await glob(`${this.paths.content}/**/*.md`, { absolute: true });
     await Promise.all(filenames.map((filename) => this.addDocument(filename, { silent: true })));
   }
 


### PR DESCRIPTION
This patch fixes hot module reloading for Markdoc content, and also fixes file watching which was broken in the 0.3.0 update. (I didn't realize chokidar had removed glob support way back when!)