### PR TITLE
Split metadata module and manifest, move manifest to a static asset

### DIFF
--- a/manifest.d.ts
+++ b/manifest.d.ts
@@ -1,5 +1,0 @@
-import type { ManifestEntry } from './src/framework';
-
-export type { ManifestEntry } from './src/framework';
-
-export let manifest: Record<string, ManifestEntry<object>>;

--- a/metadata.d.ts
+++ b/metadata.d.ts
@@ -1,0 +1,5 @@
+import type { MetadataEntry } from './src/framework';
+
+export type { MetadataEntry } from './src/framework';
+
+export let metadata: Record<string, MetadataEntry<object>>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apocrypha/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "an engine for building websites with vite and markdoc",
   "license": "MIT",
   "author": "Nate Kohari <nkohari@gmail.com>",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,4 +3,4 @@ export const ASSETS_MODULE_NAME = '@apocrypha/core/assets';
 export const CATALOG_MODULE_NAME = '@apocrypha/core/catalog';
 export const COMPONENTS_MODULE_NAME = '@apocrypha/core/components';
 export const CONFIG_MODULE_NAME = '@apocrypha/core/config';
-export const MANIFEST_MODULE_NAME = '@apocrypha/core/manifest';
+export const METADATA_MODULE_NAME = '@apocrypha/core/metadata';

--- a/src/framework/ManifestEntry.ts
+++ b/src/framework/ManifestEntry.ts
@@ -1,5 +1,0 @@
-export type ManifestEntry<TMeta extends object> = {
-  metadata: TMeta;
-  moduleFilename: string;
-  path: string;
-};

--- a/src/framework/MetadataEntry.ts
+++ b/src/framework/MetadataEntry.ts
@@ -1,0 +1,4 @@
+export type MetadataEntry<TMeta extends object> = {
+  metadata: TMeta;
+  path: string;
+};

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -1,4 +1,4 @@
 export * from './Article';
 export * from './AstWalker';
-export * from './ManifestEntry';
+export * from './MetadataEntry';
 export * from './types';


### PR DESCRIPTION
This solves the chicken-and-egg problem about being able to access the chunk filenames in the final bundle. The only real solution is to write the manifest as a static asset, and load it via `fetch()` at runtime. It can't be loaded as a virtual module, because before the bundle's actually being written, we don't know the filenames of the output chunks.