### PR TITLE
Split React functionality from catalog into a separate virtual module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,8 @@ The main export is the `apocrypha()` function, which returns a Vite plugin. The 
 
 The plugin creates several virtual modules (prefixed with `\0` in Vite's module graph):
 
-- `@apocrypha/core/catalog`: Exports `useCatalog()`, `useArticle()`, `ArticleContent`, and article metadata
+- `@apocrypha/core/catalog`: Exports article metadata (`__articles__`), loaders (`__loaders__`), registry, and `getArticleContent()` function
+- `@apocrypha/core/react`: Exports React-specific functionality: `useCatalog()`, `useArticle()`, and `ArticleContent` component
 - `@apocrypha/core/components`: Exports `useComponents()` for React components
 - `@apocrypha/core/config`: Exports `useConfig()` for Markdoc node/tag declarations
 - `@apocrypha/core/assets`: Exports `getAssetUrl()` and `getAllAssetUrlsForFolder()` for asset management

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Apocrypha will recursively find all `*.md` files within the `content` path and c
 You can get the list of articles at runtime using the `useCatalog` hook. For example:
 
 ```ts
-import {useCatalog} from '@apocrypha/core/catalog';
+import {useCatalog} from '@apocrypha/core/react';
 
 export const ArticleList = () => {
   const catalog = useCatalog();
@@ -61,12 +61,12 @@ export const ArticleList = () => {
 };
 ```
 
-(The `@apocrypha/core/catalog` module isn't actually part of the Apocrypha library; it's a _virtual module_ which is generated at build time for your project.)
+(The `@apocrypha/core/react` module isn't actually part of the Apocrypha library; it's a _virtual module_ which is generated at build time for your project.)
 
 To display an article's content, you can use the `ArticleContent` component. This is a React component which can asynchronously load the article's module and render its content using the Markdoc React renderer. The `ArticleContent` component is designed to work with [`<Suspense>`](https://react.dev/reference/react/Suspense) boundaries, which you can use to show a loading indicator. Here's an example:
 
 ```ts
-import {ArticleContent} from '@apocrypha/core/catalog';
+import {ArticleContent} from '@apocrypha/core/react';
 
 type PageProps = {
   path: string;
@@ -82,7 +82,7 @@ export const Page = ({path}: PageProps) => (
 The `ArticleContent` component also supports a `variables` prop, which you can use to pass [variables](https://markdoc.dev/docs/variables) through to your Markdoc content. For example, you could load the currently logged-in user from somewhere, and pass it to the `ArticleContent` component like this:
 
 ```ts
-import {ArticleContent} from '@apocrypha/core/catalog';
+import {ArticleContent} from '@apocrypha/core/react';
 
 type PageProps = {
   path: string;

--- a/catalog.d.ts
+++ b/catalog.d.ts
@@ -1,13 +1,8 @@
+import type { Node } from '@markdoc/markdoc';
 import type { Article } from './src/framework';
 
-export function useArticle<TMeta extends object>(path: string): Article<TMeta>;
-export function useCatalog<TMeta extends object>(): Record<string, Article<TMeta>>;
-
-type ArticleContentProps<TVariables> = {
-  path: string;
-  variables?: TVariables;
-};
-
-export function ArticleContent<TVariables = Record<string, any>>(
-  props: ArticleContentProps<TVariables>,
-): React.ReactNode;
+export function getArticle<TMeta extends object>(path: string): Article<TMeta>;
+export function getCatalog<TMeta extends object>(): Record<string, Article<TMeta>>;
+export function getArticleLoader<TMeta extends object>(
+  path: string,
+): () => Promise<{ ast: Node; metadata: TMeta }>;

--- a/catalog.d.ts
+++ b/catalog.d.ts
@@ -1,8 +1,7 @@
-import type { Node } from '@markdoc/markdoc';
-import type { Article } from './src/framework';
+import type { Article, ArticleLoader } from './src/framework';
 
-export function getArticle<TMeta extends object>(path: string): Article<TMeta>;
-export function getCatalog<TMeta extends object>(): Record<string, Article<TMeta>>;
+export function getArticle<TMeta extends object>(path: string): Article<TMeta> | undefined;
+export function getCatalog<TMeta extends object>(): Record<string, Article<TMeta>> | undefined;
 export function getArticleLoader<TMeta extends object>(
   path: string,
-): () => Promise<{ ast: Node; metadata: TMeta }>;
+): ArticleLoader<TMeta> | undefined;

--- a/metadata.d.ts
+++ b/metadata.d.ts
@@ -1,5 +1,0 @@
-import type { MetadataEntry } from './src/framework';
-
-export type { MetadataEntry } from './src/framework';
-
-export let metadata: Record<string, MetadataEntry<object>>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apocrypha/core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "an engine for building websites with vite and markdoc",
   "license": "MIT",
   "author": "Nate Kohari <nkohari@gmail.com>",

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,0 +1,13 @@
+import type { Article } from './src/framework';
+
+export function useArticle<TMeta extends object>(path: string): Article<TMeta>;
+export function useCatalog<TMeta extends object>(): Record<string, Article<TMeta>>;
+
+type ArticleContentProps<TVariables> = {
+  path: string;
+  variables?: TVariables;
+};
+
+export function ArticleContent<TVariables = Record<string, any>>(
+  props: ArticleContentProps<TVariables>,
+): React.ReactNode;

--- a/src/apocrypha.ts
+++ b/src/apocrypha.ts
@@ -8,6 +8,7 @@ import {
   COMPONENTS_MODULE_NAME,
   CONFIG_MODULE_NAME,
   METADATA_MODULE_NAME,
+  REACT_MODULE_NAME,
 } from './constants';
 import type { MetadataPlugin } from './framework';
 import { Paths } from './models';
@@ -112,7 +113,8 @@ export function apocrypha<TMeta extends object = Record<string, any>>(
         id === CATALOG_MODULE_NAME ||
         id === COMPONENTS_MODULE_NAME ||
         id === CONFIG_MODULE_NAME ||
-        id === METADATA_MODULE_NAME
+        id === METADATA_MODULE_NAME ||
+        id === REACT_MODULE_NAME
       ) {
         return mangleModuleName(id);
       }
@@ -134,6 +136,9 @@ export function apocrypha<TMeta extends object = Record<string, any>>(
       if (id === mangleModuleName(METADATA_MODULE_NAME)) {
         const documents = await catalog.getAllDocuments();
         return codeGenerator.renderMetadataModule(documents);
+      }
+      if (id === mangleModuleName(REACT_MODULE_NAME)) {
+        return codeGenerator.renderReactModule();
       }
     },
 

--- a/src/apocrypha.ts
+++ b/src/apocrypha.ts
@@ -7,7 +7,6 @@ import {
   CATALOG_MODULE_NAME,
   COMPONENTS_MODULE_NAME,
   CONFIG_MODULE_NAME,
-  METADATA_MODULE_NAME,
   REACT_MODULE_NAME,
 } from './constants';
 import type { MetadataPlugin } from './framework';
@@ -113,7 +112,6 @@ export function apocrypha<TMeta extends object = Record<string, any>>(
         id === CATALOG_MODULE_NAME ||
         id === COMPONENTS_MODULE_NAME ||
         id === CONFIG_MODULE_NAME ||
-        id === METADATA_MODULE_NAME ||
         id === REACT_MODULE_NAME
       ) {
         return mangleModuleName(id);
@@ -132,10 +130,6 @@ export function apocrypha<TMeta extends object = Record<string, any>>(
       }
       if (id === mangleModuleName(CONFIG_MODULE_NAME)) {
         return codeGenerator.renderConfigModule();
-      }
-      if (id === mangleModuleName(METADATA_MODULE_NAME)) {
-        const documents = await catalog.getAllDocuments();
-        return codeGenerator.renderMetadataModule(documents);
       }
       if (id === mangleModuleName(REACT_MODULE_NAME)) {
         return codeGenerator.renderReactModule();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,5 +3,4 @@ export const ASSETS_MODULE_NAME = '@apocrypha/core/assets';
 export const CATALOG_MODULE_NAME = '@apocrypha/core/catalog';
 export const COMPONENTS_MODULE_NAME = '@apocrypha/core/components';
 export const CONFIG_MODULE_NAME = '@apocrypha/core/config';
-export const METADATA_MODULE_NAME = '@apocrypha/core/metadata';
 export const REACT_MODULE_NAME = '@apocrypha/core/react';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,4 @@ export const CATALOG_MODULE_NAME = '@apocrypha/core/catalog';
 export const COMPONENTS_MODULE_NAME = '@apocrypha/core/components';
 export const CONFIG_MODULE_NAME = '@apocrypha/core/config';
 export const METADATA_MODULE_NAME = '@apocrypha/core/metadata';
+export const REACT_MODULE_NAME = '@apocrypha/core/react';

--- a/src/framework/ArticleLoader.ts
+++ b/src/framework/ArticleLoader.ts
@@ -1,0 +1,3 @@
+import type { ArticleModule } from './ArticleModule';
+
+export type ArticleLoader<TMeta extends object> = () => Promise<ArticleModule<TMeta>>;

--- a/src/framework/ArticleModule.ts
+++ b/src/framework/ArticleModule.ts
@@ -1,0 +1,6 @@
+export type ArticleModule<TMeta extends object> = {
+  article: {
+    ast: Node;
+    metadata: TMeta;
+  };
+};

--- a/src/framework/MetadataEntry.ts
+++ b/src/framework/MetadataEntry.ts
@@ -1,4 +1,0 @@
-export type MetadataEntry<TMeta extends object> = {
-  metadata: TMeta;
-  path: string;
-};

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -1,4 +1,5 @@
 export * from './Article';
+export * from './ArticleLoader';
+export * from './ArticleModule';
 export * from './AstWalker';
-export * from './MetadataEntry';
 export * from './types';

--- a/src/services/CodeGenerator.ts
+++ b/src/services/CodeGenerator.ts
@@ -2,7 +2,7 @@ import type { Node } from '@markdoc/markdoc';
 import type { OutputBundle, OutputChunk } from 'rollup';
 import toSource from 'tosource';
 import { CATALOG_MODULE_NAME, COMPONENTS_MODULE_NAME, CONFIG_MODULE_NAME } from '../constants';
-import type { Article, MetadataEntry } from '../framework';
+import type { Article } from '../framework';
 import type { Document, Paths } from '../models';
 import { DocumentCatalog } from './DocumentCatalog';
 
@@ -308,21 +308,6 @@ export class CodeGenerator<TMeta extends object> {
           return __components__;
         };
       }
-    `;
-  }
-
-  renderMetadataModule(documents: Document<TMeta>[]) {
-    const metadata: Record<string, MetadataEntry<TMeta>> = {};
-
-    for (const document of documents) {
-      metadata[document.id] = {
-        path: document.path,
-        metadata: document.metadata,
-      };
-    }
-
-    return `
-      export const metadata = ${toSource(metadata)};
     `;
   }
 

--- a/src/services/CodeGenerator.ts
+++ b/src/services/CodeGenerator.ts
@@ -1,7 +1,7 @@
 import type { Node } from '@markdoc/markdoc';
 import type { OutputBundle, OutputChunk } from 'rollup';
 import toSource from 'tosource';
-import { COMPONENTS_MODULE_NAME, CONFIG_MODULE_NAME } from '../constants';
+import { CATALOG_MODULE_NAME, COMPONENTS_MODULE_NAME, CONFIG_MODULE_NAME } from '../constants';
 import type { Article, MetadataEntry } from '../framework';
 import type { Document, Paths } from '../models';
 import { DocumentCatalog } from './DocumentCatalog';
@@ -86,16 +86,86 @@ export class CodeGenerator<TMeta extends object> {
     );
 
     const loaders = documents
-      .map((document) => `'${document.path}': new Loader(() => import('${document.filename}')),`)
+      .map((document) => `'${document.path}': () => import('${document.filename}'),`)
       .join('\n');
 
+    return `
+      class Registry {
+        constructor() {
+          this.entries = new Map();
+          this.listeners = new Set();
+        }
+        get(path) {
+          return this.entries.get(path);
+        }
+        put(path, article) {
+          this.entries.set(path, article);
+        }
+        subscribe(listener) {
+          this.listeners.add(listener);
+        }
+        unsubscribe(listener) {
+          this.listeners.delete(listener);
+        }
+        broadcast() {
+          this.listeners.forEach((listener) => listener());
+        }
+      }
+
+      export let __registry__;
+
+      if (typeof window !== 'undefined') {
+        if (!window.__apocrypha__) {
+          __registry__ = new Registry();
+          window.__apocrypha__ = __registry__;
+        } else {
+          __registry__ = window.__apocrypha__;
+        }
+      } else {
+        __registry__ = new Registry();
+      }
+
+      export let __articles__ = ${toSource(articles)};
+      export let __loaders__ = {
+        ${loaders}
+      };
+
+      export function getCatalog() {
+        return __articles__;
+      }
+
+      export function getArticle(path) {
+        return __articles__[path];
+      }
+
+      export function getArticleLoader(path) {
+        return __loaders__[path];
+      }
+
+      if (import.meta.hot) {
+        import.meta.hot.accept((newModule) => {
+          __articles__ = newModule.__articles__;
+          // Only add loaders for new articles
+          for (const path in newModule.__loaders__) {
+            if (!__loaders__[path]) {
+              __loaders__[path] = newModule.__loaders__[path];
+            }
+          }
+          __registry__.broadcast();
+        });
+      }
+    `;
+  }
+
+  renderReactModule() {
     return `
       import React, {useEffect, useReducer} from 'react';
       import Markdoc, {Ast} from '@markdoc/markdoc';
       import {useConfig} from '${CONFIG_MODULE_NAME}';
       import {useComponents} from '${COMPONENTS_MODULE_NAME}';
+      import {__registry__, getArticle, getCatalog, getArticleLoader} from '${CATALOG_MODULE_NAME}';
 
-      class Loader {
+      class SuspendableLoader {
         constructor(callback) {
           this.callback = callback;
           this.status = 'waiting';
@@ -119,62 +189,29 @@ export class CodeGenerator<TMeta extends object> {
         }
       }
 
-      class Registry {
-        constructor() {
-          this.entries = new Map();
-          this.listeners = new Set();
-        }
-        get(path) {
-          return this.entries.get(path);
-        }
-        put(path, article) {
-          this.entries.set(path, article);
-        }
-        subscribe(listener) {
-          this.listeners.add(listener);
-        }
-        unsubscribe(listener) {
-          this.listeners.delete(listener);
-        }
-        broadcast() {
-          this.listeners.forEach((listener) => listener());
-        }
-      }
+      const loaders = new Map();
 
-      let registry;
-
-      if (typeof window !== 'undefined') {
-        if (!window.__apocrypha__) {
-          registry = new Registry();
-          window.__apocrypha__ = registry;
-        } else {
-          registry = window.__apocrypha__;
+      function loadArticle(path) {
+        if (!loaders.has(path)) {
+          const callback = getArticleLoader(path);
+          loaders.set(path, new SuspendableLoader(callback));
         }
-      } else {
-        registry = new Registry();
-      }
 
-      export let __articles__ = ${toSource(articles)};
-      export let __loaders__ = {
-        ${loaders}
-      };
-
-      export function getArticleContent(path) {
-        __loaders__[path].load();
-        return registry.get(path);
+        loaders.get(path).load();
+        return __registry__.get(path);
       }
 
       export function ArticleContent({path, variables}) {
         const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
         useEffect(() => {
-          registry.subscribe(forceUpdate);
-          return () => registry.unsubscribe(forceUpdate);
+          __registry__.subscribe(forceUpdate);
+          return () => __registry__.unsubscribe(forceUpdate);
         }, []);
 
         const components = useComponents();
         const config = useConfig();
-        const {ast, metadata} = getArticleContent(path);
+        const {ast, metadata} = loadArticle(path);
 
         const tree = Ast.fromJSON(JSON.stringify(ast));
         const content = Markdoc.transform(tree, {
@@ -182,7 +219,7 @@ export class CodeGenerator<TMeta extends object> {
           variables,
           metadata
         });
-        
+
         return Markdoc.renderers.react(content, React, {components});
       }
 
@@ -190,35 +227,22 @@ export class CodeGenerator<TMeta extends object> {
         const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
         useEffect(() => {
-          registry.subscribe(forceUpdate);
-          return () => registry.unsubscribe(forceUpdate);
+          __registry__.subscribe(forceUpdate);
+          return () => __registry__.unsubscribe(forceUpdate);
         }, []);
 
-        return __articles__[path];
+        return getArticle(path);
       };
-      
+
       export function useCatalog() {
         const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
         useEffect(() => {
-          registry.subscribe(forceUpdate);
-          return () => registry.unsubscribe(forceUpdate);
+          __registry__.subscribe(forceUpdate);
+          return () => __registry__.unsubscribe(forceUpdate);
         }, []);
 
-        return __articles__;
-      }
-    
-      if (import.meta.hot) {
-        import.meta.hot.accept((newModule) => {
-          __articles__ = newModule.__articles__;
-          // Only add loaders for new articles
-          for (const path in newModule.__loaders__) {
-            if (!__loaders__[path]) {
-              __loaders__[path] = newModule.__loaders__[path];
-            }
-          }
-          registry.broadcast();
-        });
+        return getCatalog();
       }
     `;
   }


### PR DESCRIPTION
The catalog has value outside of React, esp. for cases like SSR. This patch moves the React-specific functionality from the `@apocrypha/core/catalog` virtual module into a new `@apocrypha/core/react` virtual module.

It also removes the `@apocrypha/core/metadata` virtual module which was created in the previous version. Metadata was already available via `@apocrypha/core/catalog`, and now that the catalog can be used anywhere, the separate metadata module is no longer necessary.